### PR TITLE
Translation pl

### DIFF
--- a/locale/pl/names.cfg
+++ b/locale/pl/names.cfg
@@ -66,7 +66,7 @@ geothermal-size=Mnożnik pozwala na kontrolę, jak duże są generowane studnie.
 geothermal-color=Kompatybilny z AlienBiomes; Wygenerowane źródło będzie miało kolor odpowiadający biomowi, w którym się pojawiło.
 geothermal-spawn-rules=W których biomach będą generowane źródła. Uwaga, w tym przypadku ilość generownaych źródeł jest stała w biomach. Jeżeli źródło wygenerowane zostanie w biomie, który jeszcze nie istnieje, to parametry generatora będą takie same, jak przy wyborze „Wszystkie biomy”.
 thermal-wagon=Jeżeli cysterny z termoizolacją są włączone, to można za ich pomocą przewozić gorącą wodę, bez utraty jej temperatury.
-geothermal-byproduct-rate=Mnożnik pozwala na kontrolę,  jak często będą pojawiać się produkty uboczne w przypadku kolorowych źródeł z moda AlienBiomes.
+geothermal-byproduct-rate=Mnożnik pozwala na kontrolę, jak często będą pojawiać się produkty uboczne w przypadku kolorowych źródeł z moda AlienBiomes.
 
 
 [string-mod-setting]

--- a/locale/pl/names.cfg
+++ b/locale/pl/names.cfg
@@ -1,0 +1,76 @@
+[item-name]
+geothermal-turbine=Turbina geotermalna
+geothermal-well=Studnia geotermalna
+geothermal-heat-exchanger=Geotermalny wymiennik ciepła
+geothermal-filter=Filtr wody geotermalnej
+insulated-wagon=Cysterna izolowana termicznie
+
+
+[fluid-name]
+geothermal-water=Woda geotermalna__1____2____3__
+
+
+[entity-name]
+geothermal-turbine=Turbina geotermalna
+geothermal-heat-exchanger=Geotermalny wymiennik ciepła
+geothermal-well=Studnia geotermalna
+geothermal=Źródło geotermalne__1__
+geothermal-filter=Filtr wody geotermalnej
+insulated-wagon=Cysterna izolowana termicznie
+
+
+[recipe-name]
+geothermal-exchange=Wymiennik ciepła
+geothermal-filter=Filtry geotermalne
+geothermal-exchange-flipped=Odwrotny wymiennik ciepła
+geothermal-exchange-2=Wysoko wydajny wymiennik ciepła
+geothermal-exchange-2-flipped=Odwrotny wysokowydajny wymiennik ciepła
+
+
+[technology-name]
+geothermal=Energetyka geotermalna
+geothermal-filtering=Filtry dla geotermii
+geothermal-2=Wysokowydajna energetyka geotermalna
+insulated-wagon=Cysterna izolowana termicznie
+
+
+[technology-description]
+geothermal=Pozwala na przekształcenie ciepła wód głębinowych i gorących skał na energię.
+geothermal-2=Rozwinięcie technologii pozwalające na wydajniejszą produkcję energii.
+geothermal-filtering=Filtry usuwają drobiny skalne, co prowadzi do uproszczenia procesu.
+insulated-wagon=Cysterany z dodatkową termoizolacją pozwalają na transport płynów i par bez strat cieplnych.
+
+
+[item-group-name]
+
+
+
+[mod-setting-name]
+geothermal-needs-water=Studnie geotermalne potrzebują wody
+geothermal-power-factor=Mnożnik produkcji energii
+geothermal-fluid-production=Mnożnik produkcji ciepła
+geothermal-frequency=Częstotliwość występowania źródeł geotermalnych
+geothermal-size=Wielkość źródeł geotermalnych
+geothermal-color=Włącz kolorowe źródła geotermalne
+geothermal-spawn-rules=Reguły biomów
+thermal-wagon=Włącz cysterny izolowane termicznie
+geothermal-byproduct-rate=Szybkość generowania produktów ubocznych
+
+
+[mod-setting-description]
+geothermal-needs-water=Czy źródło wymaga wody (energia gorących skał), czy też sama ją zawiera (gorące źródła)? Jeżeli woda jest wymagana, to logistyka będzie bardziej złożona. Uwaga, jeżeli zmienisz to ustawienie w trakcie gry, to będziesz musiał wymienić wszystkie studnie.
+geothermal-power-factor=Dostosuj ilość energii produkowanej przez geotermę.
+geothermal-fluid-production=Dostosuj ilość płynów produkowanych przez źródło. Każdy wzrost o 25% odpowiada 1-2 silnikom parowym. Przy mnożniku 1x każde źródło może zasilić 1,2 wymiennika, co odpowiada około 3 silnikom parowym.
+geothermal-frequency=Mnożnik pozwala na kontrolę, jak często generowane są studnie.
+geothermal-size=Mnożnik pozwala na kontrolę, jak duże są generowane studnie. Nie ma wpływu jeżeli zainstalowan mod AlienBiomes.
+geothermal-color=Kompatybilny z AlienBiomes; Wygenerowane źródło będzie miało kolor odpowiadający biomowi, w którym się pojawiło.
+geothermal-spawn-rules=W których biomach będą generowane źródła. Uwaga, w tym przypadku ilość generownaych źródeł jest stała w biomach. Jeżeli źródło wygenerowane zostanie w biomie, który jeszcze nie istnieje, to parametry generatora będą takie same, jak przy wyborze „Wszystkie biomy”.
+thermal-wagon=Jeżeli cysterny z termoizolacją są włączone, to można za ich pomocą przewozić gorącą wodę, bez utraty jej temperatury.
+geothermal-byproduct-rate=Mnożnik pozwala na kontrolę,  jak często będą pojawiać się produkty uboczne w przypadku kolorowych źródeł z moda AlienBiomes.
+
+
+[string-mod-setting]
+geothermal-spawn-rules-volcanic=Tylko biom wulkaniczny
+geothermal-spawn-rules-volcanic-and-snow=Biom wulkaniczny i antyczny
+geothermal-spawn-rules-volcanic-snow-and-red-desert=Biom wulkaniczny, arktyczny i czerwona pustynia
+geothermal-spawn-rules-everywhere=Wszystkie biomy


### PR DESCRIPTION
Full PL translation. All name translations and polish specific names based on:
* Wikipedia [EN](https://en.wikipedia.org/wiki/Geothermal_energy), [PL](https://pl.wikipedia.org/wiki/Energia_geotermalna)
* [Geotermia w Polsce – perspektywiczne źródło energii?](https://web.archive.org/web/20160404094759/https://www.reo.pl/komentarze/geotermia-w-polsce-perspektywiczne-zrodlo-energii--Ro9XX0) Article by PhD Michał Wilczyński.
* [Elektrociepłownie geotermalne – Vademecum dla uczniów technikum](http://www.instsani.pl/410/elektrocieplownie-geotermalne) 